### PR TITLE
optimize: replace std::thread::spawn with tokio::task::spawn_blocking…

### DIFF
--- a/src/infrastructure/font_provider.rs
+++ b/src/infrastructure/font_provider.rs
@@ -37,17 +37,12 @@ impl FontProvider {
     /// Returns `FontError::DiscoveryFailed` if the underlying font system fails to list families.
     /// Returns `FontError::ConfigFailed` if the async channel operation fails.
     pub async fn load_system_fonts_asynchronous() -> Result<Arc<Vec<String>>, FontError> {
-        let (tx, rx) = tokio::sync::oneshot::channel();
-
-        std::thread::spawn(move || {
-            let result = match &*SYSTEM_FONTS {
-                Ok(fonts) => Ok(fonts.clone()),
-                Err(_) => Err(FontError::DiscoveryFailed),
-            };
-            let _ = tx.send(result);
-        });
-
-        rx.await.map_err(|_| FontError::ConfigFailed)?
+        tokio::task::spawn_blocking(move || match &*SYSTEM_FONTS {
+            Ok(fonts) => Ok(fonts.clone()),
+            Err(_) => Err(FontError::DiscoveryFailed),
+        })
+        .await
+        .map_err(|_| FontError::ConfigFailed)?
     }
 
     /// Validate if a font family exists


### PR DESCRIPTION
Spawning a new OS thread for font loading is expensive. This change switches to `tokio::task::spawn_blocking`, which uses Tokio's managed thread pool for better performance and integration with the async runtime.

- Replaced `std::thread::spawn` with `tokio::task::spawn_blocking`.
- Removed manual `oneshot` channel in favor of awaiting the `JoinHandle`.
- Preserved existing error handling logic.