### PR TITLE
feat: add --no-ui flag to skip Dashboard on startup

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -30,6 +30,7 @@ use tracing::{debug, error, info, warn};
 pub struct App {
     gtk_app: Application,
     config_service: ConfigService,
+    no_ui: bool,
     #[allow(dead_code)]
     audio_engine: Arc<Mutex<Option<AudioEngine>>>,
     audio_dispatcher: Option<AudioDispatcher>,
@@ -55,7 +56,7 @@ struct RuntimeState {
 
 impl App {
     #[must_use]
-    pub fn new(config_service: ConfigService) -> Self {
+    pub fn new(config_service: ConfigService, no_ui: bool) -> Self {
         let gtk_app = Application::builder()
             .application_id("dev.linuxmobile.hibiki")
             .build();
@@ -71,6 +72,7 @@ impl App {
         Self {
             gtk_app,
             config_service,
+            no_ui,
             audio_engine: Arc::new(Mutex::new(audio_engine)),
             audio_dispatcher,
         }
@@ -81,6 +83,7 @@ impl App {
         let config_service = self.config_service.clone();
         let audio_dispatcher = self.audio_dispatcher.clone();
         let audio_engine_container = self.audio_engine.clone();
+        let no_ui = self.no_ui;
 
         self.gtk_app.connect_activate(move |app| {
             let audio_engine = audio_engine_container.lock().take();
@@ -91,6 +94,7 @@ impl App {
                 tray_handle.clone(),
                 audio_dispatcher.clone(),
                 audio_engine,
+                no_ui,
             );
         });
 
@@ -104,10 +108,11 @@ impl App {
         let config_service = self.config_service.clone();
         let audio_dispatcher = self.audio_dispatcher.clone();
         let audio_engine_container = self.audio_engine.clone();
+        let no_ui = self.no_ui;
 
         self.gtk_app.connect_activate(move |app| {
             let audio_engine = audio_engine_container.lock().take();
-            activate_without_tray(app, &config_service, audio_dispatcher.clone(), audio_engine);
+            activate_without_tray(app, &config_service, audio_dispatcher.clone(), audio_engine, no_ui);
         });
 
         let exit_code = self.gtk_app.run_with_args::<&str>(&[]);
@@ -122,6 +127,7 @@ fn activate_without_tray(
     config_service: &ConfigService,
     audio_dispatcher: Option<AudioDispatcher>,
     audio_engine: Option<AudioEngine>,
+    no_ui: bool,
 ) {
     info!("Activating keystroke application (no tray)");
 
@@ -146,7 +152,7 @@ fn activate_without_tray(
     crate::ui::update_css_provider(&css_provider, &config);
     state.borrow_mut().css_provider = Some(css_provider);
 
-    setup_launcher_and_modes(app, &state, config_service.clone());
+    setup_launcher_and_modes(app, &state, config_service.clone(), no_ui);
 }
 
 fn activate(
@@ -156,6 +162,7 @@ fn activate(
     tray_handle: TrayHandle,
     audio_dispatcher: Option<AudioDispatcher>,
     audio_engine: Option<AudioEngine>,
+    no_ui: bool,
 ) {
     info!("Activating keystroke application");
 
@@ -180,7 +187,7 @@ fn activate(
     crate::ui::update_css_provider(&css_provider, &config);
     state.borrow_mut().css_provider = Some(css_provider);
 
-    setup_launcher_and_modes(app, &state, config_service.clone());
+    setup_launcher_and_modes(app, &state, config_service.clone(), no_ui);
 
     setup_tray_handling(
         Rc::clone(&state),
@@ -195,6 +202,7 @@ fn setup_launcher_and_modes(
     app: &Application,
     state: &Rc<RefCell<RuntimeState>>,
     config_service: ConfigService,
+    no_ui: bool,
 ) {
     let app_for_mode = app.clone();
     let state_for_mode = Rc::clone(state);
@@ -222,7 +230,14 @@ fn setup_launcher_and_modes(
 
     state.borrow_mut().launcher_window = Some(launcher.clone());
 
-    show_launcher(&launcher);
+    if no_ui {
+        // Skip the Dashboard. Use display_mode from config to pick which
+        // visualizer to start, defaulting to Keystroke if unset.
+        let mode = config_service.get_config().display_mode;
+        switch_mode(app, state, &config_service, mode);
+    } else {
+        show_launcher(&launcher);
+    }
 }
 
 fn switch_mode(

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,15 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilte
 fn main() -> Result<()> {
     init_logging();
 
+    // Parse --no-ui / -n before GTK sees the args.
+    // GTK's own arg parser will error on unknown flags, so we strip ours out
+    // by passing an empty arg list to GTK later (run_with_args::<&str>(&[])).
+    let no_ui = std::env::args().any(|a| a == "--no-ui" || a == "-n");
+
     info!("Starting Hibiki v{}", env!("CARGO_PKG_VERSION"));
+    if no_ui {
+        info!("--no-ui flag set: skipping Dashboard window");
+    }
 
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -37,15 +45,13 @@ fn main() -> Result<()> {
     match tray::start_tray() {
         Ok((tray_rx, tray_handle)) => {
             info!("System tray started successfully");
-
-            let app = app::App::new(config_service);
+            let app = app::App::new(config_service, no_ui);
             let exit_code = app.run_with_tray(tray_rx, tray_handle);
             std::process::exit(exit_code);
         }
         Err(e) => {
             warn!("Failed to start system tray: {}, running without tray", e);
-
-            let app = app::App::new(config_service);
+            let app = app::App::new(config_service, no_ui);
             let exit_code = app.run();
             std::process::exit(exit_code);
         }


### PR DESCRIPTION
**Problem**
When running hibiki via exec-once in Hyprland (or from a terminal), the Dashboard window always opens on startup even when the user just wants the keystroke visualizer running in the background. The display_mode field in config.toml exists but was never used anywhere in the code.

**Solution**
Adds a `--no-ui` / `-n` flag that skips the Dashboard and starts the visualizer directly using display_mode from config to decide which mode to launch (defaults to keystroke).

`exec-once = hibiki --no-ui`

The launcher window is still created in the background so the tray menu's "Show Launcher" still works normally.

Testing
Tested on Hyprland. `cargo run -- --no-ui` starts the keystroke overlay with no Dashboard window.